### PR TITLE
feat: Generate the remote backend config used by the engine to connect to the remote backend dockerd

### DIFF
--- a/generate_cloud_connection.sh
+++ b/generate_cloud_connection.sh
@@ -7,12 +7,12 @@ if [ -z "$1" ]; then
 fi
 
 if [ -z "$2" ]; then
-  echo "Error: No name defined as first argument"
+  echo "Error: No name defined as second argument"
   missing_var=true
 fi
 
 if [ -z "$3" ]; then
-  echo "Error: No IP defined as first argument"
+  echo "Error: No IP defined as third argument"
   missing_var=true
 fi
 

--- a/generate_remote_backend_config.sh
+++ b/generate_remote_backend_config.sh
@@ -19,11 +19,14 @@ replace_values () {
   sed -i 's!'"$TARGET"'!'"$REPLACEMENT"'!g' "$CONFIG_FILE"
 }
 
-ca_pem_base64=$(base64 -i ca.pem)
-client_cert_base64=$(base64 -i client-cert.pem)
-client_key=$(base64 -i client-key.pem)
+ca_pem_base64=$(base64 -w0 ca.pem)
+client_cert_base64=$(base64 -w0 client-cert.pem)
+client_key=$(base64 -w0 client-key.pem)
 
 replace_values "{ENDPOINT}" "$ENDPOINT"
 replace_values "{CA}" "$ca_pem_base64"
 replace_values "{CLIENT_CERT}" "$client_cert_base64"
 replace_values "{CLIENT_KEY}" "$client_key"
+
+mkdir -p /root/engine_config
+cp remote_backend_config.json /root/engine_config

--- a/generate_remote_backend_config.sh
+++ b/generate_remote_backend_config.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+missing_var=false
+if [ -z "$1" ]; then
+  echo "Error: No endpoint defined as first argument"
+  missing_var=true
+fi
+
+if [ "$missing_var" = true ]; then
+  exit 1
+fi
+
+ENDPOINT="$1"
+CONFIG_FILE="remote_backend_config.json"
+
+replace_values () {
+  TARGET=$1
+  REPLACEMENT=$2
+  sed -i 's!'"$TARGET"'!'"$REPLACEMENT"'!g' "$CONFIG_FILE"
+}
+
+ca_pem_base64=$(base64 -i ca.pem)
+client_cert_base64=$(base64 -i client-cert.pem)
+client_key=$(base64 -i client-key.pem)
+
+replace_values "{ENDPOINT}" "$ENDPOINT"
+replace_values "{CA}" "$ca_pem_base64"
+replace_values "{CLIENT_CERT}" "$client_cert_base64"
+replace_values "{CLIENT_KEY}" "$client_key"

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 apt-get update
 apt-get install -y ca-certificates curl gnupg lsb-release jq
 mkdir -m 0755 -p /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor --yes -o /etc/apt/keyrings/docker.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/nullapt-get update
 apt-get update
 apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin

--- a/remote_backend_config.json
+++ b/remote_backend_config.json
@@ -1,0 +1,8 @@
+{
+  "endpoint": "{ENDPOINT}",
+  "tlsConfig": {
+    "certificateAuthority": "{CA}",
+    "clientCertificate": "{CLIENT_CERT}",
+    "clientKey": "{CLIENT_KEY}"
+  }
+}

--- a/run.sh
+++ b/run.sh
@@ -41,9 +41,11 @@ PASSWORD="$3"
 UUID="$4"
 NAME="$5"
 WORK_DIR="$6"
+# Set remote backend endpoint to localhost for now since the remote backend host and the bastion are the same host. 
+REMOTE_BACKEND_ENDPOINT="127.0.0.1"
 
 sh generate_certificates.sh  "$HOST" "$IP" "$PASSWORD"
 sh install.sh
 sh configure_processes.sh "$WORK_DIR"
 sh generate_cloud_connection.sh "$UUID" "$NAME" "$IP"
-
+sh generate_remote_backend_config.sh "$REMOTE_BACKEND_ENDPOINT"

--- a/run.sh
+++ b/run.sh
@@ -41,8 +41,8 @@ PASSWORD="$3"
 UUID="$4"
 NAME="$5"
 WORK_DIR="$6"
-# Set remote backend endpoint to localhost for now since the remote backend host and the bastion are the same host. 
-REMOTE_BACKEND_ENDPOINT="127.0.0.1"
+# Set remote backend endpoint host to this host for now since the remote backend host and the bastion are the same host.
+REMOTE_BACKEND_ENDPOINT="tcp://$IP:9722"
 
 sh generate_certificates.sh  "$HOST" "$IP" "$PASSWORD"
 sh install.sh


### PR DESCRIPTION
The engine is now running on the bastion (kloud instance) and it requires a remote backend config to connect to the remote backend dockerd.  The config contains an endpoint and the TLS certs.  The endpoint is currently set to the bastion (kloud instance) IP since the bastion and the remote backend host are the same hosts at this stage.  A subsequent PR will deploy the bastion and the remote backend host as two different hosts.

Reference: https://www.notion.so/kurtosistech/Kloud-Bastion-Docker-and-K8S-backends-71a19e630ed0454a984042e1cafb1a88

Kurtosis repo PR: https://github.com/kurtosis-tech/kurtosis/pull/963